### PR TITLE
Adding maxLabelLength to VAnnotator props

### DIFF
--- a/src/components/VAnnotator.vue
+++ b/src/components/VAnnotator.vue
@@ -17,6 +17,7 @@
               item.textLine.endOffset
             )
           "
+          :maxLabelLength="maxLabelLength"
           :relationLabels="relationLabelList"
           :font="font"
           :rtl="rtl"
@@ -79,6 +80,11 @@ export default Vue.extend({
   },
 
   props: {
+    maxLabelLength: {
+      type: Number,
+      default: 12,
+      required: false,
+    },
     text: {
       type: String,
       default: "",
@@ -173,6 +179,7 @@ export default Vue.extend({
           widthOf(label.text, this.textElement!)
         );
         return LabelList.valueOf(
+          this.maxLabelLength,
           this.entityLabels,
           widths,
           EntityLabelListItem
@@ -187,6 +194,7 @@ export default Vue.extend({
           widthOf(label.text, this.textElement!)
         );
         return LabelList.valueOf(
+          this.maxLabelLength,
           this.relationLabels,
           widths,
           RelationLabelListItem

--- a/src/domain/models/Label/Label.ts
+++ b/src/domain/models/Label/Label.ts
@@ -73,6 +73,7 @@ export class LabelList {
   }
 
   static valueOf(
+    maxLabelLength: number,
     labels: Label[],
     widths: number[],
     itemClass: typeof LabelListItem
@@ -84,7 +85,8 @@ export class LabelList {
             label.id,
             label.text,
             (label.color || label.backgroundColor)!,
-            widths[index]
+            widths[index],
+            maxLabelLength
           )
       )
     );

--- a/tests/unit/domain/models/Label/labels.spec.ts
+++ b/tests/unit/domain/models/Label/labels.spec.ts
@@ -78,6 +78,7 @@ describe("Labels", () => {
     const labelObjects = [{ id, text, color }];
     const widths = [10];
     const entityLabels = LabelList.valueOf(
+      config.maxLabelLength,
       labelObjects,
       widths,
       EntityLabelListItem


### PR DESCRIPTION
1. Add maxLabelLength to VAnnotator props.
2. Change [valueOf](https://github.com/doccano/v-annotator/blob/c757441bcbf023c75780b0c92e7d0547ce6dd667/src/domain/models/Label/Label.ts#L75) method to pass maxLabelLength.
3. Pass maxLabelLength to LabelList.valueOf in the VAnnotator component.