### PR TITLE
Prevent SVG `defs` from taking up space

### DIFF
--- a/src/components/VAnnotator.vue
+++ b/src/components/VAnnotator.vue
@@ -1,6 +1,6 @@
 <template>
   <div :id="`container-${uuid}`" @click="open" @touchend="open">
-    <svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="0" height="0">
       <defs>
         <marker
           id="v-annotator-arrow"


### PR DESCRIPTION
When implementing #6 I didn't notice that the SVG element I added (containing only marker definitions) took up space due to its default size. This PR removes that space by setting its size to 0. Using `display: none` wouldn't work because then the `defs` don't take effect anymore.